### PR TITLE
Create a symlink instead of copying the file

### DIFF
--- a/include/linuxdeploy/util/misc.h
+++ b/include/linuxdeploy/util/misc.h
@@ -6,10 +6,33 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <boost/filesystem.hpp>
 
 namespace linuxdeploy {
     namespace util {
         namespace misc {
+            static bool path_contains_file(boost::filesystem::path dir, boost::filesystem::path file) {
+                // If dir ends with "/" and isn't the root directory, then the final
+                // component returned by iterators will include "." and will interfere
+                // with the std::equal check below, so we strip it before proceeding.
+                if (dir.filename() == ".")
+                    dir.remove_filename();
+                // We're also not interested in the file's name.
+                assert(file.has_filename());
+                file.remove_filename();
+
+                // If dir has more components than file, then file can't possibly
+                // reside in dir.
+                auto dir_len = std::distance(dir.begin(), dir.end());
+                auto file_len = std::distance(file.begin(), file.end());
+                if (dir_len > file_len)
+                    return false;
+
+                // This stops checking when it reaches dir.end(), so it's OK if file
+                // has more directory components afterward. They won't be checked.
+                return std::equal(dir.begin(), dir.end(), file.begin());
+            };
+
             static inline bool ltrim(std::string& s, char to_trim = ' ') {
                 // TODO: find more efficient way to check whether elements have been removed
                 size_t initialLength = s.length();

--- a/src/core/appdir.cpp
+++ b/src/core/appdir.cpp
@@ -20,6 +20,7 @@
 #include "excludelist.h"
 
 using namespace linuxdeploy::core;
+using namespace linuxdeploy::util::misc;
 using namespace linuxdeploy::core::log;
 
 using namespace cimg_library;
@@ -159,8 +160,10 @@ namespace linuxdeploy {
                             const auto& from = pair.first;
                             const auto& to = pair.second;
 
-                            if (!copyFile(from, to))
-                                success = false;
+                            if (path_contains_file(appDirPath, from)) {
+                                success = bf::exists(to) || symlinkFile(from, to, true); // create a symbolic link
+                            } else
+                                success = copyFile(from, to); // copy the file
 
                             copyOperations.erase(copyOperations.begin());
                         }


### PR DESCRIPTION
Create a symlink instead of copying the file when `deployFile` is requested with source and target paths inside the AppDir

There are situations in which we would like to provide the same file from different locations inside the AppDir. But making copies of it is not quite optimal therefore we will create symlinks instead.

Currently, we have an issue with the [qt translations files](https://github.com/linuxdeploy/linuxdeploy-plugin-qt/issues/16) as there is not a real standard place where they should be deployed applications installations place them wherever they think is better. In order to make those translations available to the application, we must move them to "AppDir/usr/translations" but moving the whole file can cause failures as some applications may expect them to be in a fixed path. Therefore we left the files at their installation path and create symlinks from the "AppDir/usr/translations".