### PR TITLE
Test desktopfile parser conformance

### DIFF
--- a/include/linuxdeploy/core/desktopfile/desktopfileentry.h
+++ b/include/linuxdeploy/core/desktopfile/desktopfileentry.h
@@ -56,11 +56,11 @@ namespace linuxdeploy {
 
                 // convert value to integer
                 // throws boost::bad_lexical_cast in case of type errors
-                int asInt() const;
+                int32_t asInt() const;
 
                 // convert value to long
                 // throws boost::bad_lexical_cast in case of type errors
-                long asLong() const;
+                int64_t asLong() const;
 
                 // convert value to double
                 // throws boost::bad_lexical_cast in case of type errors

--- a/include/linuxdeploy/core/desktopfile/exceptions.h
+++ b/include/linuxdeploy/core/desktopfile/exceptions.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// system includes
+#include <stdexcept>
+#include <string>
+
+namespace linuxdeploy {
+    namespace core {
+        namespace desktopfile {
+            /**
+             * Desktop file library's base exception.
+             */
+            class DesktopFileError : public std::runtime_error {
+            public:
+                explicit DesktopFileError(const std::string& message = "unknown desktop file error") : runtime_error(message) {};
+            };
+
+            /**
+             * Exception thrown by DesktopFileReader on parsing errors.
+             */
+            class ParseError : public DesktopFileError {
+            public:
+                explicit ParseError(const std::string& message = "unknown parse error") : DesktopFileError(message) {};
+            };
+
+            /**
+             * I/O exception, thrown if files cannot be opened, reading or writing fails etc.
+             */
+             class IOError : public DesktopFileError {
+             public:
+                 explicit IOError(const std::string& message = "unknown I/O error") : DesktopFileError(message) {};
+             };
+
+             class UnknownSectionError : public DesktopFileError {
+             public:
+                 explicit UnknownSectionError(const std::string& section) : DesktopFileError("unknown section: " + section) {};
+             };
+        }
+    }
+}

--- a/src/core/desktopfile/desktopfile.cpp
+++ b/src/core/desktopfile/desktopfile.cpp
@@ -75,7 +75,7 @@ namespace linuxdeploy {
                 clear();
 
                 DesktopFileReader reader(path);
-                d->data = reader.data();
+                d->data = std::move(reader.data());
             }
 
             void DesktopFile::read(std::istream& is) {

--- a/src/core/desktopfile/desktopfileentry.cpp
+++ b/src/core/desktopfile/desktopfileentry.cpp
@@ -78,16 +78,16 @@ namespace linuxdeploy {
                 return d->value;
             }
 
-            int DesktopFileEntry::asInt() const {
+            int32_t DesktopFileEntry::asInt() const {
                 d->assertValueNotEmpty();
 
-                return lexical_cast<int>(value());
+                return lexical_cast<int32_t>(value());
             }
 
-            long DesktopFileEntry::asLong() const {
+            int64_t DesktopFileEntry::asLong() const {
                 d->assertValueNotEmpty();
 
-                return lexical_cast<long>(value());
+                return lexical_cast<int64_t>(value());
             }
 
             double DesktopFileEntry::asDouble() const {

--- a/src/core/desktopfile/desktopfilereader.cpp
+++ b/src/core/desktopfile/desktopfilereader.cpp
@@ -56,10 +56,13 @@ namespace linuxdeploy {
                                 !((len >= 2 && (line[0] == '/' && line[1] == '/')) || (len >= 1 && line[0] == '#'))) {
                                 if (line[0] == '[') {
                                     // this line apparently introduces a new section
-                                    auto closingBracketPos = line.find_last_of(']');
+                                    auto closingBracketPos = line.find(']');
+                                    auto lastClosingBracketPos = line.find_last_of(']');
 
                                     if (closingBracketPos == std::string::npos)
                                         throw ParseError("No closing ] bracket in section header");
+                                    else if (closingBracketPos != lastClosingBracketPos)
+                                        throw ParseError("Two or more closing ] brackets in section header");
 
                                     size_t length = len - 2;
                                     auto title = line.substr(1, closingBracketPos - 1);

--- a/src/core/desktopfile/desktopfilereader.cpp
+++ b/src/core/desktopfile/desktopfilereader.cpp
@@ -94,6 +94,12 @@ namespace linuxdeploy {
                                     if (key.empty())
                                         throw ParseError("Empty keys are not allowed");
 
+                                    // keys may only contain A-Za-z- characters according to specification
+                                    for (const auto c : key) {
+                                        if (!(c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c == '-'))
+                                            throw ParseError("Key contains invalid character " + std::string{c});
+                                    }
+
                                     // who are we to judge whether empty values are an issue
                                     // that'd require checking the key names and implementing checks per key according to the
                                     // freedesktop.org spec

--- a/src/core/desktopfile/desktopfilereader.cpp
+++ b/src/core/desktopfile/desktopfilereader.cpp
@@ -105,10 +105,13 @@ namespace linuxdeploy {
                                             throw ParseError("Key contains invalid character " + std::string{c});
                                     }
 
-                                    // who are we to judge whether empty values are an issue
-                                    // that'd require checking the key names and implementing checks per key according to the
-                                    // freedesktop.org spec
-                                    sections[currentSectionName][key] = DesktopFileEntry(key, value);
+                                    auto& section = sections[currentSectionName];
+
+                                    // keys must be unique in the same section
+                                    if (section.find(key) != section.end())
+                                        throw ParseError("Key " + key + " found more than once");
+
+                                    section[key] = DesktopFileEntry(key, value);
                                 }
                             }
                         }

--- a/src/core/desktopfile/desktopfilereader.cpp
+++ b/src/core/desktopfile/desktopfilereader.cpp
@@ -78,9 +78,13 @@ namespace linuxdeploy {
                                     if (currentSectionName.empty())
                                         throw ParseError("No section in desktop file");
 
+                                    auto delimiterPos = line.find('=');
+                                    if (delimiterPos == std::string::npos)
+                                        throw ParseError("No = key/value delimiter found");
+
                                     // this line should be a normal key-value pair
-                                    std::string key = line.substr(0, line.find('='));
-                                    std::string value = line.substr(line.find('=') + 1, line.size());
+                                    std::string key = line.substr(0, delimiterPos);
+                                    std::string value = line.substr(delimiterPos + 1, line.size());
 
                                     // we can strip away any sort of leading or trailing whitespace safely
                                     linuxdeploy::util::trim(key);

--- a/src/core/desktopfile/desktopfilereader.cpp
+++ b/src/core/desktopfile/desktopfilereader.cpp
@@ -56,8 +56,13 @@ namespace linuxdeploy {
                                 !((len >= 2 && (line[0] == '/' && line[1] == '/')) || (len >= 1 && line[0] == '#'))) {
                                 if (line[0] == '[') {
                                     // this line apparently introduces a new section
+                                    auto closingBracketPos = line.find_last_of(']');
+
+                                    if (closingBracketPos == std::string::npos)
+                                        throw ParseError("No closing ] bracket in section header");
+
                                     size_t length = len - 2;
-                                    auto title = line.substr(1, line.find(']') - 1);
+                                    auto title = line.substr(1, closingBracketPos - 1);
 
                                     // set up the new section
                                     sections.insert(std::make_pair(title, DesktopFile::section_t()));

--- a/src/core/desktopfile/desktopfilereader.cpp
+++ b/src/core/desktopfile/desktopfilereader.cpp
@@ -55,6 +55,9 @@ namespace linuxdeploy {
                             if (len > 0 &&
                                 !((len >= 2 && (line[0] == '/' && line[1] == '/')) || (len >= 1 && line[0] == '#'))) {
                                 if (line[0] == '[') {
+                                    if (line.find_last_of('[') != 0)
+                                        throw ParseError("Multiple opening [ brackets");
+
                                     // this line apparently introduces a new section
                                     auto closingBracketPos = line.find(']');
                                     auto lastClosingBracketPos = line.find_last_of(']');

--- a/src/core/desktopfile/desktopfilereader.cpp
+++ b/src/core/desktopfile/desktopfilereader.cpp
@@ -97,7 +97,10 @@ namespace linuxdeploy {
                                     // keys may only contain A-Za-z- characters according to specification
                                     for (const char c : key) {
                                         if (!(
-                                                (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || (c == '-')
+                                                (c >= 'A' && c <= 'Z') ||
+                                                (c >= 'a' && c <= 'z') ||
+                                                (c >= '0' && c <= '9') ||
+                                                (c == '-')
                                             ))
                                             throw ParseError("Key contains invalid character " + std::string{c});
                                     }

--- a/src/core/desktopfile/desktopfilereader.cpp
+++ b/src/core/desktopfile/desktopfilereader.cpp
@@ -95,8 +95,10 @@ namespace linuxdeploy {
                                         throw ParseError("Empty keys are not allowed");
 
                                     // keys may only contain A-Za-z- characters according to specification
-                                    for (const auto c : key) {
-                                        if (!(c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c == '-'))
+                                    for (const char c : key) {
+                                        if (!(
+                                                (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || (c == '-')
+                                            ))
                                             throw ParseError("Key contains invalid character " + std::string{c});
                                     }
 

--- a/src/core/desktopfile/desktopfilereader.cpp
+++ b/src/core/desktopfile/desktopfilereader.cpp
@@ -7,6 +7,7 @@
 // local headers
 #include "linuxdeploy/util/util.h"
 #include "linuxdeploy/core/desktopfile/desktopfileentry.h"
+#include "linuxdeploy/core/desktopfile/exceptions.h"
 #include "desktopfilereader.h"
 
 namespace bf = boost::filesystem;
@@ -26,7 +27,7 @@ namespace linuxdeploy {
 
                 void assertPathIsNotEmptyAndFileExists() {
                     if (path.empty())
-                        throw std::invalid_argument("empty path is not permitted");
+                        throw IOError("empty path is not permitted");
                 }
 
                 void copyData(const std::shared_ptr<PrivateData>& other) {
@@ -64,7 +65,7 @@ namespace linuxdeploy {
                                 } else {
                                     // we require at least one section to be present in the desktop file
                                     if (currentSectionName.empty())
-                                        throw std::invalid_argument("No section in desktop file");
+                                        throw ParseError("No section in desktop file");
 
                                     // this line should be a normal key-value pair
                                     std::string key = line.substr(0, line.find('='));
@@ -76,7 +77,7 @@ namespace linuxdeploy {
 
                                     // empty keys are not allowed for obvious reasons
                                     if (key.empty())
-                                        throw std::invalid_argument("Empty keys are not allowed");
+                                        throw ParseError("Empty keys are not allowed");
 
                                     // who are we to judge whether empty values are an issue
                                     // that'd require checking the key names and implementing checks per key according to the
@@ -97,7 +98,7 @@ namespace linuxdeploy {
 
                 std::ifstream ifs(d->path.string());
                 if (!ifs)
-                    throw std::invalid_argument("could not open file: " + d->path.string());
+                    throw IOError("could not open file: " + d->path.string());
 
                 d->parse(ifs);
             }
@@ -156,7 +157,7 @@ namespace linuxdeploy {
                 // the map would lazy-initialize a new entry in case the section doesn't exist
                 // therefore explicitly checking whether the section exists, throwing an exception in case it does not
                 if (it == d->sections.end())
-                    throw std::range_error("could not find section " + name);
+                    throw UnknownSectionError(name);
 
                 return it->second;
             }

--- a/src/core/desktopfile/desktopfilewriter.cpp
+++ b/src/core/desktopfile/desktopfilewriter.cpp
@@ -4,6 +4,7 @@
 
 // local headers
 #include "linuxdeploy/util/util.h"
+#include "linuxdeploy/core/desktopfile/exceptions.h"
 #include "desktopfilewriter.h"
 
 namespace bf = boost::filesystem;
@@ -88,7 +89,7 @@ namespace linuxdeploy {
                 std::ofstream ofs(path.string());
 
                 if (!ofs)
-                    throw std::runtime_error("could not open file for writing: " + path.string());
+                    throw IOError("could not open file for writing: " + path.string());
 
                 save(ofs);
             }

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -54,7 +54,7 @@ add_test(test_desktopfileentry test_desktopfileentry)
 add_executable(test_desktopfilewriter test_desktopfilewriter.cpp)
 target_link_libraries(test_desktopfilewriter PRIVATE linuxdeploy_core gtest gtest_main)
 
-add_test(test_desktopfileentry test_desktopfilewriter)
+add_test(test_desktopfilewriter test_desktopfilewriter)
 
 
 add_executable(test_desktopfile test_desktopfile.cpp)
@@ -63,4 +63,4 @@ set_property(TARGET test_desktopfile
     PROPERTY COMPILE_FLAGS "-DDESKTOP_FILE_PATH=\\\"${CMAKE_CURRENT_SOURCE_DIR}/../data/simple_app.desktop\\\""
 )
 
-add_test(test_desktopfileentry test_desktopfilewriter)
+add_test(test_desktopfile test_desktopfile)

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -40,25 +40,25 @@ add_dependencies(test_linuxdeploy simple_library simple_executable)
 
 
 add_executable(test_desktopfilereader test_desktopfilereader.cpp)
-target_link_libraries(test_desktopfilereader PRIVATE linuxdeploy_core gtest gtest_main)
+target_link_libraries(test_desktopfilereader PRIVATE linuxdeploy_core_desktopfile gtest gtest_main)
 
 add_test(test_desktopfilereader test_desktopfilereader)
 
 
 add_executable(test_desktopfileentry test_desktopfileentry.cpp)
-target_link_libraries(test_desktopfileentry PRIVATE linuxdeploy_core gtest gtest_main)
+target_link_libraries(test_desktopfileentry PRIVATE linuxdeploy_core_desktopfile gtest gtest_main)
 
 add_test(test_desktopfileentry test_desktopfileentry)
 
 
 add_executable(test_desktopfilewriter test_desktopfilewriter.cpp)
-target_link_libraries(test_desktopfilewriter PRIVATE linuxdeploy_core gtest gtest_main)
+target_link_libraries(test_desktopfilewriter PRIVATE linuxdeploy_core_desktopfile gtest gtest_main)
 
 add_test(test_desktopfilewriter test_desktopfilewriter)
 
 
 add_executable(test_desktopfile test_desktopfile.cpp)
-target_link_libraries(test_desktopfile PRIVATE linuxdeploy_core gtest gtest_main)
+target_link_libraries(test_desktopfile PRIVATE linuxdeploy_core_desktopfile gtest gtest_main)
 set_property(TARGET test_desktopfile
     PROPERTY COMPILE_FLAGS "-DDESKTOP_FILE_PATH=\\\"${CMAKE_CURRENT_SOURCE_DIR}/../data/simple_app.desktop\\\""
 )
@@ -67,6 +67,6 @@ add_test(test_desktopfile test_desktopfile)
 
 
 add_executable(test_desktopfile_conformance test_desktopfile_conformance.cpp)
-target_link_libraries(test_desktopfile_conformance PRIVATE linuxdeploy_core gtest gtest_main)
+target_link_libraries(test_desktopfile_conformance PRIVATE linuxdeploy_core_desktopfile gtest gtest_main)
 
 add_test(test_desktopfile_conformance test_desktopfile_conformance)

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -64,3 +64,9 @@ set_property(TARGET test_desktopfile
 )
 
 add_test(test_desktopfile test_desktopfile)
+
+
+add_executable(test_desktopfile_conformance test_desktopfile_conformance.cpp)
+target_link_libraries(test_desktopfile_conformance PRIVATE linuxdeploy_core gtest gtest_main)
+
+add_test(test_desktopfile_conformance test_desktopfile_conformance)

--- a/tests/core/test_desktopfile_conformance.cpp
+++ b/tests/core/test_desktopfile_conformance.cpp
@@ -24,7 +24,7 @@ TEST_F(DesktopFileConformanceTest, testBasicFormatInvalidKeyCharacters) {
         ss << "[Desktop Entry]" << std::endl
            << "no spaces in key=foo" << std::endl;
 
-        ASSERT_THROW(DesktopFile file(ss), ParseError);
+        EXPECT_THROW(DesktopFile file(ss), ParseError);
     }
 
     {
@@ -32,7 +32,7 @@ TEST_F(DesktopFileConformanceTest, testBasicFormatInvalidKeyCharacters) {
         ss << "[Desktop Entry]" << std::endl
            << "UmlautTestÄöÜ=foo" << std::endl;
 
-        ASSERT_THROW(DesktopFile file(ss), ParseError);
+        EXPECT_THROW(DesktopFile file(ss), ParseError);
     }
 
     {
@@ -40,7 +40,7 @@ TEST_F(DesktopFileConformanceTest, testBasicFormatInvalidKeyCharacters) {
         ss << "[Desktop Entry]" << std::endl
            << "NoUnderscores_=foo" << std::endl;
 
-        ASSERT_THROW(DesktopFile file(ss), ParseError);
+        EXPECT_THROW(DesktopFile file(ss), ParseError);
     }
 }
 
@@ -50,7 +50,7 @@ TEST_F(DesktopFileConformanceTest, testBasicFormatValidKeyCharacters) {
         ss << "[Desktop Entry]" << std::endl
            << "TestKey=foo" << std::endl;
 
-        ASSERT_THROW(DesktopFile file(ss), ParseError);
+        EXPECT_THROW(DesktopFile file(ss), ParseError);
     }
 
     {
@@ -58,7 +58,7 @@ TEST_F(DesktopFileConformanceTest, testBasicFormatValidKeyCharacters) {
         ss << "[Desktop Entry]" << std::endl
            << "4242trolol0=foo" << std::endl;
 
-        ASSERT_THROW(DesktopFile file(ss), ParseError);
+        EXPECT_THROW(DesktopFile file(ss), ParseError);
     }
 
     {
@@ -66,6 +66,6 @@ TEST_F(DesktopFileConformanceTest, testBasicFormatValidKeyCharacters) {
         ss << "[Desktop Entry]" << std::endl
            << "----=foo" << std::endl;
 
-        ASSERT_THROW(DesktopFile file(ss), ParseError);
+        EXPECT_THROW(DesktopFile file(ss), ParseError);
     }
 }

--- a/tests/core/test_desktopfile_conformance.cpp
+++ b/tests/core/test_desktopfile_conformance.cpp
@@ -77,3 +77,14 @@ TEST_F(DesktopFileConformanceTest, testBasicFormatValidKeyCharacters) {
         EXPECT_NO_THROW(DesktopFile file(ss));
     }
 }
+
+TEST_F(DesktopFileConformanceTest, testBasicFormatCheckKeysUnique) {
+    {
+        std::stringstream ss;
+        ss << "[Desktop Entry]" << std::endl
+           << "foo=bar" << std::endl
+           << "foo=baz" << std::endl;
+
+        EXPECT_THROW(DesktopFile file(ss), ParseError);
+    }
+}

--- a/tests/core/test_desktopfile_conformance.cpp
+++ b/tests/core/test_desktopfile_conformance.cpp
@@ -1,0 +1,71 @@
+// library headers
+#include <gtest/gtest.h>
+#include <boost/filesystem.hpp>
+
+// local headers
+#include "linuxdeploy/core/desktopfile/desktopfile.h"
+#include "linuxdeploy/core/desktopfile/exceptions.h"
+
+using boost::bad_lexical_cast;
+using namespace linuxdeploy::core::desktopfile;
+
+namespace bf = boost::filesystem;
+
+class DesktopFileConformanceTest : public ::testing::Test {
+private:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(DesktopFileConformanceTest, testBasicFormatInvalidKeyCharacters) {
+    // test conformance with a couple of invalid values
+    {
+        std::stringstream ss;
+        ss << "[Desktop Entry]" << std::endl
+           << "no spaces in key=foo" << std::endl;
+
+        ASSERT_THROW(DesktopFile file(ss), ParseError);
+    }
+
+    {
+        std::stringstream ss;
+        ss << "[Desktop Entry]" << std::endl
+           << "UmlautTestÄöÜ=foo" << std::endl;
+
+        ASSERT_THROW(DesktopFile file(ss), ParseError);
+    }
+
+    {
+        std::stringstream ss;
+        ss << "[Desktop Entry]" << std::endl
+           << "NoUnderscores_=foo" << std::endl;
+
+        ASSERT_THROW(DesktopFile file(ss), ParseError);
+    }
+}
+
+TEST_F(DesktopFileConformanceTest, testBasicFormatValidKeyCharacters) {
+    {
+        std::stringstream ss;
+        ss << "[Desktop Entry]" << std::endl
+           << "TestKey=foo" << std::endl;
+
+        ASSERT_THROW(DesktopFile file(ss), ParseError);
+    }
+
+    {
+        std::stringstream ss;
+        ss << "[Desktop Entry]" << std::endl
+           << "4242trolol0=foo" << std::endl;
+
+        ASSERT_THROW(DesktopFile file(ss), ParseError);
+    }
+
+    {
+        std::stringstream ss;
+        ss << "[Desktop Entry]" << std::endl
+           << "----=foo" << std::endl;
+
+        ASSERT_THROW(DesktopFile file(ss), ParseError);
+    }
+}

--- a/tests/core/test_desktopfile_conformance.cpp
+++ b/tests/core/test_desktopfile_conformance.cpp
@@ -50,7 +50,7 @@ TEST_F(DesktopFileConformanceTest, testBasicFormatValidKeyCharacters) {
         ss << "[Desktop Entry]" << std::endl
            << "TestKey=foo" << std::endl;
 
-        EXPECT_THROW(DesktopFile file(ss), ParseError);
+        EXPECT_NO_THROW(DesktopFile file(ss));
     }
 
     {
@@ -58,7 +58,7 @@ TEST_F(DesktopFileConformanceTest, testBasicFormatValidKeyCharacters) {
         ss << "[Desktop Entry]" << std::endl
            << "4242trolol0=foo" << std::endl;
 
-        EXPECT_THROW(DesktopFile file(ss), ParseError);
+        EXPECT_NO_THROW(DesktopFile file(ss));
     }
 
     {
@@ -66,6 +66,14 @@ TEST_F(DesktopFileConformanceTest, testBasicFormatValidKeyCharacters) {
         ss << "[Desktop Entry]" << std::endl
            << "----=foo" << std::endl;
 
-        EXPECT_THROW(DesktopFile file(ss), ParseError);
+        EXPECT_NO_THROW(DesktopFile file(ss));
+    }
+
+    {
+        std::stringstream ss;
+        ss << "[Desktop Entry]" << std::endl
+           << "allLowerCase=foo" << std::endl;
+
+        EXPECT_NO_THROW(DesktopFile file(ss));
     }
 }

--- a/tests/core/test_desktopfilereader.cpp
+++ b/tests/core/test_desktopfilereader.cpp
@@ -217,3 +217,11 @@ TEST_F(DesktopFileReaderFixture, testReadBrokenSectionHeaderTooManyClosingBracke
 
     ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
 }
+
+TEST_F(DesktopFileReaderFixture, testReadBrokenSectionHeaderTooManyOpeningBrackets) {
+    std::stringstream ins;
+    ins << "[[Desktop Entry]" << std::endl
+        << "test=test" << std::endl;
+
+    ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+}

--- a/tests/core/test_desktopfilereader.cpp
+++ b/tests/core/test_desktopfilereader.cpp
@@ -203,25 +203,61 @@ TEST_F(DesktopFileReaderFixture, testParseLinesWithMultipleSpaces) {
 }
 
 TEST_F(DesktopFileReaderFixture, testReadBrokenSectionHeaderMissingClosingBracket) {
-    std::stringstream ins;
-    ins << "[Desktop Entry" << std::endl
-        << "test=test" << std::endl;
+    {
+        std::stringstream ins;
+        ins << "[Desktop Entry" << std::endl
+            << "test=test" << std::endl;
 
-    ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+        ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+    }
+
+    // also test for brokenness in a later section, as the first section is normally treated specially
+    {
+        std::stringstream ins;
+        ins << "[Desktop Entry]" << std::endl
+            << "test=test" << std::endl
+            << "[Another Section" << std::endl;
+
+        ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+    }
 }
 
 TEST_F(DesktopFileReaderFixture, testReadBrokenSectionHeaderTooManyClosingBrackets) {
-    std::stringstream ins;
-    ins << "[Desktop Entry]]" << std::endl
-        << "test=test" << std::endl;
+    {
+        std::stringstream ins;
+        ins << "[Desktop Entry]]" << std::endl
+            << "test=test" << std::endl;
 
-    ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+        ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+    }
+
+    // also test for brokenness in a later section, as the first section is normally treated specially
+    {
+        std::stringstream ins;
+        ins << "[Desktop Entry]" << std::endl
+            << "test=test" << std::endl
+            << "[Another Section]]" << std::endl;
+
+        ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+    }
 }
 
 TEST_F(DesktopFileReaderFixture, testReadBrokenSectionHeaderTooManyOpeningBrackets) {
-    std::stringstream ins;
-    ins << "[[Desktop Entry]" << std::endl
-        << "test=test" << std::endl;
+    {
+        std::stringstream ins;
+        ins << "[[Desktop Entry]" << std::endl
+            << "test=test" << std::endl;
 
-    ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+        ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+    }
+
+    // also test for brokenness in a later section, as the first section is normally treated specially
+    {
+        std::stringstream ins;
+        ins << "[Desktop Entry]" << std::endl
+            << "test=test" << std::endl
+            << "[[Another Section]";
+
+        ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+    }
 }

--- a/tests/core/test_desktopfilereader.cpp
+++ b/tests/core/test_desktopfilereader.cpp
@@ -154,6 +154,26 @@ TEST_F(DesktopFileReaderFixture, testParseFileEmptyKey) {
 }
 
 TEST_F(DesktopFileReaderFixture, testParseFileMissingDelimiterInLine) {
+    {
+        std::stringstream ss;
+        ss << "[Desktop File]" << std::endl
+           << "Exec" << std::endl;
+
+        DesktopFileReader reader;
+        ASSERT_THROW(reader = DesktopFileReader(ss), ParseError);
+    }
+
+    {
+        std::stringstream ss;
+        ss << "[Desktop File]" << std::endl
+           << "Name name" << std::endl;
+
+        DesktopFileReader reader;
+        ASSERT_THROW(reader = DesktopFileReader(ss), ParseError);
+    }
+}
+
+TEST_F(DesktopFileReaderFixture, testParseFile) {
     std::stringstream ss;
     ss << "[Desktop File]" << std::endl
        << "Name name" << std::endl

--- a/tests/core/test_desktopfilereader.cpp
+++ b/tests/core/test_desktopfilereader.cpp
@@ -4,6 +4,7 @@
 
 // local headers
 #include "../../src/core/desktopfile/desktopfilereader.h"
+#include "linuxdeploy/core/desktopfile/exceptions.h"
 
 using namespace linuxdeploy::core::desktopfile;
 namespace bf = boost::filesystem;
@@ -24,7 +25,7 @@ TEST_F(DesktopFileReaderFixture, testPathConstructor) {
     DesktopFileReader reader(path);
     EXPECT_TRUE(reader.isEmpty());
 
-    ASSERT_THROW(DesktopFileReader("/no/such/file/or/directory"), std::invalid_argument);
+    ASSERT_THROW(DesktopFileReader("/no/such/file/or/directory"), IOError);
 }
 
 TEST_F(DesktopFileReaderFixture, testStreamConstructor) {
@@ -35,11 +36,11 @@ TEST_F(DesktopFileReaderFixture, testStreamConstructor) {
 }
 
 TEST_F(DesktopFileReaderFixture, testPathConstructorWithEmptyPath) {
-    ASSERT_THROW(DesktopFileReader(""), std::invalid_argument);
+    ASSERT_THROW(DesktopFileReader(""), IOError);
 }
 
 TEST_F(DesktopFileReaderFixture, testPathConstructorWithNonExistingPath) {
-    ASSERT_THROW(DesktopFileReader("/no/such/path/42"), std::invalid_argument);
+    ASSERT_THROW(DesktopFileReader("/no/such/path/42"), IOError);
 }
 
 TEST_F(DesktopFileReaderFixture, testEqualityAndInequalityOperators) {
@@ -124,7 +125,7 @@ TEST_F(DesktopFileReaderFixture, testParseFileGetNonExistingSection) {
     DesktopFileReader reader;
     reader = DesktopFileReader(ss);
 
-    ASSERT_THROW(reader["Non-existing Section"], std::range_error);
+    ASSERT_THROW(reader["Non-existing Section"], UnknownSectionError);
 }
 
 TEST_F(DesktopFileReaderFixture, testParseFileMissingSectionHeader) {
@@ -136,7 +137,7 @@ TEST_F(DesktopFileReaderFixture, testParseFileMissingSectionHeader) {
        << "Categories=Utility;Multimedia;" << std::endl;
 
     DesktopFileReader reader;
-    ASSERT_THROW(reader = DesktopFileReader(ss), std::invalid_argument);
+    ASSERT_THROW(reader = DesktopFileReader(ss), ParseError);
 }
 
 TEST_F(DesktopFileReaderFixture, testParseFileEmptyKey) {
@@ -149,7 +150,7 @@ TEST_F(DesktopFileReaderFixture, testParseFileEmptyKey) {
        << "Categories=Utility;Multimedia;" << std::endl;
 
     DesktopFileReader reader;
-    ASSERT_THROW(reader = DesktopFileReader(ss), std::invalid_argument);
+    ASSERT_THROW(reader = DesktopFileReader(ss), ParseError);
 }
 
 TEST_F(DesktopFileReaderFixture, testParseFileWithLeadingAndTrailingWhitespaceInLines) {

--- a/tests/core/test_desktopfilereader.cpp
+++ b/tests/core/test_desktopfilereader.cpp
@@ -153,6 +153,16 @@ TEST_F(DesktopFileReaderFixture, testParseFileEmptyKey) {
     ASSERT_THROW(reader = DesktopFileReader(ss), ParseError);
 }
 
+TEST_F(DesktopFileReaderFixture, testParseFileMissingDelimiterInLine) {
+    std::stringstream ss;
+    ss << "[Desktop File]" << std::endl
+       << "Name name" << std::endl
+       << "Exec" << std::endl;
+
+    DesktopFileReader reader;
+    ASSERT_THROW(reader = DesktopFileReader(ss), ParseError);
+}
+
 TEST_F(DesktopFileReaderFixture, testParseFileWithLeadingAndTrailingWhitespaceInLines) {
     std::stringstream ss;
     ss << "[Desktop File]" << std::endl

--- a/tests/core/test_desktopfilereader.cpp
+++ b/tests/core/test_desktopfilereader.cpp
@@ -261,3 +261,22 @@ TEST_F(DesktopFileReaderFixture, testReadBrokenSectionHeaderTooManyOpeningBracke
         ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
     }
 }
+
+TEST_F(DesktopFileReaderFixture, testReadBrokenSectionMissingOpeningBracket) {
+    {
+        std::stringstream ins;
+        ins << "Desktop Entry]" << std::endl
+            << "test=test" << std::endl;
+        ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+    }
+
+    // also test for brokenness in a later section, as the first section is normally treated specially
+    {
+        std::stringstream ins;
+        ins << "[Desktop Entry]" << std::endl
+            << "test=test" << std::endl
+            << "Another Section]" << std::endl;
+
+        ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+    }
+}

--- a/tests/core/test_desktopfilereader.cpp
+++ b/tests/core/test_desktopfilereader.cpp
@@ -202,9 +202,17 @@ TEST_F(DesktopFileReaderFixture, testParseLinesWithMultipleSpaces) {
     EXPECT_EQ(section["Name"].value(), "What a great  name");
 }
 
-TEST_F(DesktopFileReaderFixture, testReadBrokenSectionHeader) {
+TEST_F(DesktopFileReaderFixture, testReadBrokenSectionHeaderMissingClosingBracket) {
     std::stringstream ins;
     ins << "[Desktop Entry" << std::endl
+        << "test=test" << std::endl;
+
+    ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+}
+
+TEST_F(DesktopFileReaderFixture, testReadBrokenSectionHeaderTooManyClosingBrackets) {
+    std::stringstream ins;
+    ins << "[Desktop Entry]]" << std::endl
         << "test=test" << std::endl;
 
     ASSERT_THROW(DesktopFileReader reader(ins), ParseError);

--- a/tests/core/test_desktopfilereader.cpp
+++ b/tests/core/test_desktopfilereader.cpp
@@ -201,3 +201,11 @@ TEST_F(DesktopFileReaderFixture, testParseLinesWithMultipleSpaces) {
 
     EXPECT_EQ(section["Name"].value(), "What a great  name");
 }
+
+TEST_F(DesktopFileReaderFixture, testReadBrokenSectionHeader) {
+    std::stringstream ins;
+    ins << "[Desktop Entry" << std::endl
+        << "test=test" << std::endl;
+
+    ASSERT_THROW(DesktopFileReader reader(ins), ParseError);
+}

--- a/tests/core/test_desktopfilereader.cpp
+++ b/tests/core/test_desktopfilereader.cpp
@@ -163,6 +163,16 @@ TEST_F(DesktopFileReaderFixture, testParseFileMissingDelimiterInLine) {
     ASSERT_THROW(reader = DesktopFileReader(ss), ParseError);
 }
 
+TEST_F(DesktopFileReaderFixture, testParseFileMultipleDelimitersInLine) {
+    // TODO: verify that ==Name would be a legal value according to desktop file specification
+    std::stringstream ss;
+    ss << "[Desktop File]" << std::endl
+       << "Name===name" << std::endl;
+
+    DesktopFileReader reader;
+    ASSERT_NO_THROW(reader = DesktopFileReader(ss));
+}
+
 TEST_F(DesktopFileReaderFixture, testParseFileWithLeadingAndTrailingWhitespaceInLines) {
     std::stringstream ss;
     ss << "[Desktop File]" << std::endl

--- a/tests/core/test_desktopfilewriter.cpp
+++ b/tests/core/test_desktopfilewriter.cpp
@@ -5,6 +5,7 @@
 // local headers
 #include "../../src/core/desktopfile/desktopfilewriter.h"
 #include "../../src/core/desktopfile/desktopfilereader.h"
+#include "linuxdeploy/core/desktopfile/exceptions.h"
 
 using namespace linuxdeploy::core::desktopfile;
 namespace bf = boost::filesystem;
@@ -68,7 +69,7 @@ TEST_F(DesktopFileWriterFixture, testSaveToPath) {
 
 TEST_F(DesktopFileWriterFixture, testSaveToInvalidPath) {
     DesktopFileWriter writer;
-    ASSERT_THROW(writer.save("/a/b/c/d/e/f/g/h/1/2/3/4/5/6/7/8"), std::runtime_error);
+    ASSERT_THROW(writer.save("/a/b/c/d/e/f/g/h/1/2/3/4/5/6/7/8"), IOError);
 }
 
 TEST_F(DesktopFileWriterFixture, testSaveToStream) {


### PR DESCRIPTION
This PR validates conformance with the ["basic format"](https://standards.freedesktop.org/desktop-entry-spec/latest/ar01s03.html) description in the standard by testing for valid and invalid values using unit tests.

Comments are not supported yet, and therefore are not covered by the tests.

Support for comments will be added in a future PR. Same goes for proper localization support.