### PR TITLE
Fix desktop file parser unit test failures

### DIFF
--- a/src/core/desktopfile/desktopfile.cpp
+++ b/src/core/desktopfile/desktopfile.cpp
@@ -144,7 +144,7 @@ namespace linuxdeploy {
             }
 
             bool DesktopFile::setEntry(const std::string& section, DesktopFileEntry&& entry) {
-                  // check if value exists -- used for return value
+                // check if value exists -- used for return value
                 auto rv = entryExists(section, entry.key());
 
                 d->data[section][entry.key()] = entry;
@@ -156,10 +156,11 @@ namespace linuxdeploy {
                 if (!entryExists(section, key))
                     return false;
 
+                entry = d->data[section][key];
+
                 // make sure keys are equal
                 assert(key == entry.key());
 
-                entry = d->data[section][key];
                 return true;
             }
 
@@ -179,8 +180,8 @@ namespace linuxdeploy {
                         ldLog() << LD_WARNING << "Key exists, not modified:" << key << "(current value:" << entry.value() << LD_NO_SPACE << ")" << std::endl;
                         rv = false;
                     } else {
-                        auto entrySet = setEntry(section, DesktopFileEntry(key, value));
-                        assert(entrySet);
+                        auto entryOverwritten = setEntry(section, DesktopFileEntry(key, value));
+                        assert(!entryOverwritten);
                     }
                 };
 

--- a/src/core/desktopfile/desktopfile.cpp
+++ b/src/core/desktopfile/desktopfile.cpp
@@ -173,12 +173,14 @@ namespace linuxdeploy {
                         DesktopFileEntry entry;
 
                         // this should never return false
-                        assert(getEntry(section, key, entry));
+                        auto entryExists = getEntry(section, key, entry);
+                        assert(entryExists);
 
                         ldLog() << LD_WARNING << "Key exists, not modified:" << key << "(current value:" << entry.value() << LD_NO_SPACE << ")" << std::endl;
                         rv = false;
                     } else {
-                        assert(!setEntry(section, std::move(DesktopFileEntry(key, value))));
+                        auto entrySet = setEntry(section, DesktopFileEntry(key, value));
+                        assert(entrySet);
                     }
                 };
 

--- a/src/core/desktopfile/desktopfile.cpp
+++ b/src/core/desktopfile/desktopfile.cpp
@@ -156,6 +156,9 @@ namespace linuxdeploy {
                 if (!entryExists(section, key))
                     return false;
 
+                // make sure keys are equal
+                assert(key == entry.key());
+
                 entry = d->data[section][key];
                 return true;
             }

--- a/tests/core/desktopfile/test_desktopfile.cpp
+++ b/tests/core/desktopfile/test_desktopfile.cpp
@@ -138,12 +138,21 @@ TEST_F(DesktopFileTest, testMoveAssignmentConstructor) {
     assertIsTestDesktopFile(copy);
 }
 
-/* deactivated until further notice as they won't run on Travis CI for some reason
+void assertDefaultKeysExistInDesktopFile(const DesktopFile& file) {
+    DesktopFileEntry entry;
+
+    for (const auto& key : {"Name", "Exec", "Icon", "Type"})
+        EXPECT_TRUE(file.getEntry("Desktop Entry", key, entry)) << "Could not find key in desktop file: " << key;
+}
+
 TEST_F(DesktopFileTest, testAddDefaultValues) {
     const auto& value = "testExecutable";
 
     DesktopFile file;
     file.addDefaultKeys(value);
+
+    // make sure keys exist in desktop files
+    assertDefaultKeysExistInDesktopFile(file);
 
     std::stringstream ss;
 
@@ -169,6 +178,11 @@ TEST_F(DesktopFileTest, testAddDefaultValuesExistingKeys) {
     DesktopFile file(iss);
     file.addDefaultKeys(value);
 
+    // make sure keys exist in desktop files
+    assertDefaultKeysExistInDesktopFile(file);
+
+    file.save(std::cout);
+
     std::stringstream ss;
 
     file.save(ss);
@@ -178,7 +192,6 @@ TEST_F(DesktopFileTest, testAddDefaultValuesExistingKeys) {
     EXPECT_EQ(reader["Desktop Entry"]["Name"].value(), "A Different Name");
     EXPECT_EQ(reader["Desktop Entry"]["Exec"].value(), "a_different_exec");
     EXPECT_EQ(reader["Desktop Entry"]["Icon"].value(), value);
-    EXPECT_EQ(reader["Desktop Entry"]["Type"].value(), "Application");
     EXPECT_EQ(reader["Desktop Entry"]["Categories"].value(), "Utility;");
 }
 
@@ -190,6 +203,9 @@ TEST_F(DesktopFileTest, testAddDefaultValuesNoOverwrite) {
     DesktopFile file(iss);
 
     file.addDefaultKeys(value);
+
+    // make sure keys exist in desktop files
+    assertDefaultKeysExistInDesktopFile(file);
 
     {
         std::stringstream oss;
@@ -208,7 +224,6 @@ TEST_F(DesktopFileTest, testAddDefaultValuesNoOverwrite) {
         EXPECT_EQ(reader["Desktop Entry"]["Categories"].parseStringList(), std::vector<std::string>({"Utility"}));
     }
 }
-*/
 
 TEST_F(DesktopFileTest, testSaveToPath) {
     std::stringstream ins;


### PR DESCRIPTION
Turned out some wrongly used `assert()`s caused the issues.