### PR TITLE
remove all comments

### DIFF
--- a/src/core/generate-excludelist.sh
+++ b/src/core/generate-excludelist.sh
@@ -18,7 +18,7 @@ log_prefix="-- [$(basename $0)]"
 
 echo "$log_prefix downloading excludelist from GitHub"
 url="https://raw.githubusercontent.com/probonopd/AppImages/master/excludelist"
-blacklisted=($(wget --quiet "$url" -O - | sort | uniq | grep -v "^#.*" | grep "[^-\s]"))
+blacklisted=($(wget --quiet "$url" -O - | sed 's|#.*||g' | sort | uniq))
 
 # sanity check
 if [ "$blacklisted" == "" ]; then


### PR DESCRIPTION
Otherwise the generated header contains entries like this:
``` c
    "libxcb-dri2.so.0",
    "#",
    "https://github.com/probonopd/linuxdeployqt/issues/331#issuecomment-442276277",
    "libxcb-dri3.so.0",
    "#",
    "https://github.com/AppImage/AppImages/issues/348",
```