### PR TITLE
Build all binaries on CentOS 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,30 +3,31 @@ sudo: required
 
 matrix:
   include:
-    - env: ARCH=x86_64
-      addons:
-        apt:
-          update: true
-          packages:
-            - libmagic-dev
-            - libjpeg-dev
-            - libpng-dev
-            - cimg-dev
-            - automake  # required for patchelf
-    - env: ARCH=i386
-      addons:
-        apt:
-          update: true
-          packages:
-            - libmagic-dev:i386
-            - libjpeg-dev:i386
-            - libpng-dev:i386
-            - gcc-multilib
-            - g++-multilib
-            - automake  # required for patchelf
-            - libfuse2:i386
-            - libcairo2:i386
-    - env: ARCH=x86_64 BUILD_TYPE=coverage
+    - name: CentOS 6 x86_64 build
+      env: ARCH=x86_64 BUILD_TYPE=centos6
+      install: true
+      services:
+        - docker
+      script: travis/build-centos6-docker.sh
+      after_success:
+        - if [ "$TRAVIS_BRANCH" != "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" != "master" ]; then export TRAVIS_EVENT_TYPE=pull_request; fi
+        - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+        - bash upload.sh linuxdeploy-centos6-"$ARCH".AppImage*
+
+    - name: CentOS 6 i386 build
+      env: ARCH=i386 BUILD_TYPE=centos6
+      install: true
+      services:
+        - docker
+      script: travis/build-centos6-docker.sh
+      after_success:
+        - if [ "$TRAVIS_BRANCH" != "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" != "master" ]; then export TRAVIS_EVENT_TYPE=pull_request; fi
+        - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+        - bash upload.sh linuxdeploy-centos6-"$ARCH".AppImage*
+
+    - name: Ubuntu xenial x86_64 coverage build (no binaries uploaded)
+      env: ARCH=x86_64 BUILD_TYPE=coverage
+      dist: xenial
       addons:
         apt:
           update: true
@@ -39,7 +40,10 @@ matrix:
         - sudo pip install gcovr
       script: travis/test-coverage.sh
       after_success: true  # also, we don't intend to upload release binaries
-    - env: ARCH=i386 BUILD_TYPE=coverage
+
+    - name: Ubuntu xenial i386 coverage build (no binaries uploaded)
+      env: ARCH=i386 BUILD_TYPE=coverage
+      dist: xenial
       addons:
         apt:
           update: true
@@ -55,38 +59,6 @@ matrix:
         - sudo pip install gcovr
       script: travis/test-coverage.sh
       after_success: true  # also, we don't intend to upload release binaries
-    - env: ARCH=x86_64 BUILD_TYPE=centos6
-      install: true
-      services:
-        - docker
-      script: travis/build-centos6-docker.sh
-      after_success:
-        - if [ "$TRAVIS_BRANCH" != "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" != "master" ]; then export TRAVIS_EVENT_TYPE=pull_request; fi
-        - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
-        - bash upload.sh linuxdeploy-centos6-"$ARCH".AppImage*
-    - env: ARCH=i386 BUILD_TYPE=centos6
-      install: true
-      services:
-        - docker
-      script: travis/build-centos6-docker.sh
-      after_success:
-        - if [ "$TRAVIS_BRANCH" != "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" != "master" ]; then export TRAVIS_EVENT_TYPE=pull_request; fi
-        - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
-        - bash upload.sh linuxdeploy-centos6-"$ARCH".AppImage*
-
-install:
-  - git clone https://github.com/NixOS/patchelf.git -b 0.8
-  - cd patchelf
-  - ./bootstrap.sh
-  - if [ "$ARCH" == "i386" ]; then ./configure --prefix=/usr --build=i686-pc-linux-gnu CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32; fi
-  - if [ "$ARCH" == "x86_64" ]; then ./configure --prefix=/usr; fi
-  - make -j$(nproc)
-  - sudo make install
-  - cd ..
-  - rm -rf patchelf
-
-script:
-  - travis/build.sh
 
 after_success:
   - ls -lh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       after_success:
         - if [ "$TRAVIS_BRANCH" != "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" != "master" ]; then export TRAVIS_EVENT_TYPE=pull_request; fi
         - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
-        - bash upload.sh linuxdeploy-centos6-"$ARCH".AppImage*
+        - bash upload.sh linuxdeploy-"$ARCH".AppImage*
 
     - name: CentOS 6 i386 build
       env: ARCH=i386 BUILD_TYPE=centos6
@@ -23,7 +23,7 @@ matrix:
       after_success:
         - if [ "$TRAVIS_BRANCH" != "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" != "master" ]; then export TRAVIS_EVENT_TYPE=pull_request; fi
         - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
-        - bash upload.sh linuxdeploy-centos6-"$ARCH".AppImage*
+        - bash upload.sh linuxdeploy-"$ARCH".AppImage*
 
     - name: Ubuntu xenial x86_64 coverage build (no binaries uploaded)
       env: ARCH=x86_64 BUILD_TYPE=coverage
@@ -59,13 +59,6 @@ matrix:
         - sudo pip install gcovr
       script: travis/test-coverage.sh
       after_success: true  # also, we don't intend to upload release binaries
-
-after_success:
-  - ls -lh
-  # make sure only pushes to rewrite create a new release, otherwise pretend PR and upload to transfer.sh
-  - if [ "$TRAVIS_BRANCH" != "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" != "master" ]; then export TRAVIS_EVENT_TYPE=pull_request; fi
-  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
-  - bash upload.sh linuxdeploy-"$ARCH".AppImage*
 
 branches:
   except:

--- a/travis/Dockerfile.centos6
+++ b/travis/Dockerfile.centos6
@@ -20,3 +20,5 @@ RUN yum install -y gcc-c++ && \
     make install && \
     popd && \
     rm -r patchelf/
+
+CMD ["bash"]

--- a/travis/Dockerfile.centos6-i386
+++ b/travis/Dockerfile.centos6-i386
@@ -41,3 +41,4 @@ RUN yum install -y gcc-c++ && \
     popd && \
     rm -r patchelf/
 
+CMD ["bash"]

--- a/travis/Dockerfile.centos6-i386
+++ b/travis/Dockerfile.centos6-i386
@@ -28,11 +28,6 @@ RUN git clone https://github.com/Kitware/CMake && \
     make install && \
     cd .. && \
     rm -r CMake/
-#    wget https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz -O- | tar xz --strip-components=1 -C/usr/local
-
-#RUN wget http://springdale.math.ias.edu/data/puias/computational/6/x86_64//patchelf-0.8-2.sdl6.x86_64.rpm && \
-#    echo "3d746306f5f7958b9487e6d08f53bb13  patchelf-0.8-2.sdl6.x86_64.rpm" || md5sum -c && \
-#    rpm -i patchelf-0.8-2.sdl6.x86_64.rpm
 
 RUN yum install -y gcc-c++ && \
     git clone https://github.com/NixOS/patchelf.git && \

--- a/travis/build-centos6-docker.sh
+++ b/travis/build-centos6-docker.sh
@@ -15,4 +15,4 @@ fi
 
 (cd "$here" && docker build -f "$DOCKERFILE" -t "$IMAGE" .)
 
-docker run --rm -i -v "$here"/..:/ws:ro -v "$old_cwd":/out -e OUTDIR_OWNER=$(id -u) "$IMAGE" /bin/bash -xe /ws/travis/build-centos6.sh
+docker run --rm -it -v "$here"/..:/ws:ro -v "$old_cwd":/out -e CI=1 -e OUTDIR_OWNER=$(id -u) "$IMAGE" /bin/bash -xe -c "cd /out && /ws/travis/build-centos6.sh"

--- a/travis/build-centos6.sh
+++ b/travis/build-centos6.sh
@@ -17,8 +17,6 @@ LINUXDEPLOY_ARGS=("--appdir" "AppDir" "-e" "bin/linuxdeploy" "-i" "/ws/resources
 # deploy patchelf which is a dependency of linuxdeploy
 bin/linuxdeploy "${LINUXDEPLOY_ARGS[@]}"
 
-tar cfvz /out/appdir.tgz AppDir
-
 # cannot add appimage plugin yet, since it won't work on CentOS 6 (at least for now)
 # therefore we also need to use appimagetool directly to build an AppImage
 # but we can still prepare the AppDir

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -75,12 +75,13 @@ mv squashfs-root/ AppDir/plugins/linuxdeploy-plugin-appimage
 ln -s ../../plugins/linuxdeploy-plugin-appimage/AppRun AppDir/usr/bin/linuxdeploy-plugin-appimage
 
 export UPD_INFO="gh-releases-zsync|linuxdeploy|linuxdeploy|continuous|linuxdeploy-$ARCH.AppImage"
+export OUTPUT="linuxdeploy-devbuild-$ARCH.AppImage"
 
 # build AppImage using plugin
 AppDir/usr/bin/linuxdeploy-plugin-appimage --appdir AppDir/
 
 # rename AppImage to avoid "Text file busy" issues when using it to create another one
-mv ./linuxdeploy-"$ARCH".AppImage test.AppImage
+mv "$OUTPUT" test.AppImage
 
 # verify that the resulting AppImage works
 ./test.AppImage "${LINUXDEPLOY_ARGS[@]}"
@@ -88,4 +89,4 @@ mv ./linuxdeploy-"$ARCH".AppImage test.AppImage
 # check whether AppImage plugin is found and works
 ./test.AppImage "${LINUXDEPLOY_ARGS[@]}" --output appimage
 
-mv linuxdeploy-"$ARCH".AppImage* "$OLD_CWD"
+mv "$OUTPUT"* "$OLD_CWD"/


### PR DESCRIPTION
This PR makes the CentOS 6 build script feature complete (as in performing the same steps as the old one), makes use of the new linuxdeploy-plugin-appimage builds (also built on CentOS 6). Furthermore, it adjusts the output AppImage naming so that the CentOS 6 binaries will be a drop-in replacement for the old ones built on Ubuntu xenial.

Fixes #94, #65. CC #80.