### PR TITLE
Update README.md with CPU-X project

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This is an incomplete list of projects using linuxdeploy. You might want to read
 - [AppImageUpdate](https://github.com/AppImage/AppImageUpdate)
 - [appimaged](https://github.com/AppImage/appimaged)
 - [MediaElch](https://github.com/Komet/MediaElch/)
+- [CPU-X](https://github.com/X0rg/CPU-X) (details available [here](https://github.com/AppImage/AppImageKit/wiki/Bundling-GTK3-apps#fully-automated-deployment-from-sources-with-github-actions-cpu-x))
 
 
 ## Plugins


### PR DESCRIPTION
Hello,

I just wanted to leave some feedback about my personal experience to bundle a **GTK 3** application with AppImage. I found a lot of out of date examples with GTK 2, but [this guide](https://docs.appimage.org/packaging-guide/manual.html#bundling-gtk-libraries) was a good starting point.

So I wrote a guide on [AppImageKit wiki](https://github.com/AppImage/AppImageKit/wiki/Bundling-GTK3-apps#fully-automated-deployment-from-sources-with-github-actions-cpu-x). I hope it can be useful for someone who wants to bundle a GTK 3 application, because it was a bit painful for me. :sweat_smile: 