### PR TITLE
Fix update information used by Travis builds

### DIFF
--- a/travis/build-centos6.sh
+++ b/travis/build-centos6.sh
@@ -49,7 +49,7 @@ mv squashfs-root/ AppDir/plugins/linuxdeploy-plugin-appimage
 
 ln -s ../../plugins/linuxdeploy-plugin-appimage/AppRun AppDir/usr/bin/linuxdeploy-plugin-appimage
 
-export UPD_INFO="gh-releases-zsync|linuxdeploy|linuxdeploy|continuous|linuxdeploy-$ARCH.AppImage"
+export UPD_INFO="gh-releases-zsync|linuxdeploy|linuxdeploy|continuous|linuxdeploy-$ARCH.AppImage.zsync"
 export OUTPUT=linuxdeploy-"$ARCH".AppImage
 
 # build AppImage using plugin


### PR DESCRIPTION
Seems like this was overlooked by commit 2af5430 when fixing #126

I noticed the AppImage on the releases page still does not contain the right update information despite the earlier patch to address #126.

If I understand the build/deploy configuration properly, Travis uses the `travis/build-centos6.sh` script to build, so the change to the update information in `build.sh` wasn't being used:

    .travis.yml -> travis/build-centos6-docker.sh -> travis/build-centos6.sh

This file still had the old update info without the `.zsync` suffix.