### PR TITLE
Read ldd error message from both stdout and stderr

### DIFF
--- a/src/core/elf.cpp
+++ b/src/core/elf.cpp
@@ -162,7 +162,7 @@ namespace linuxdeploy {
                 const auto result = lddProc.run();
 
                 if (result.exit_code() != 0) {
-                    if (result.stdout_string().find("not a dynamic executable") != std::string::npos) {
+                    if (result.stdout_string().find("not a dynamic executable") != std::string::npos || result.stderr_string().find("not a dynamic executable") != std::string::npos) {
                         ldLog() << LD_WARNING << this->d->path << "is not linked dynamically" << std::endl;
                         return {};
                     }


### PR DESCRIPTION
This should fix #147 .

Details:

- `ldd` is used to determine a list of shared libraries an executable binary was linked against.
- `linuxdeploy` reads `ldd` error message from `stdout` only.
- from [`glibc 2.31`](https://sourceware.org/bugzilla/show_bug.cgi?id=24150#c3), `ldd` [has been changed](https://sourceware.org/git/?p=glibc.git;a=commit;f=elf/ldd.bash.in;h=e7c8ffe4ec059da1523c093d6a240cd87d154df2) to print all error messages to `stderr`.