### PR TITLE
subprocess: Add missing include for std::runtime_error

### DIFF
--- a/src/subprocess/pipe_reader.cpp
+++ b/src/subprocess/pipe_reader.cpp
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <functional>
 #include <cstring>
+#include <stdexcept>
 
 // local headers
 #include "linuxdeploy/subprocess/pipe_reader.h"


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>