### PR TITLE
Export TEXTDOMAINDIR in AppRun script

### DIFF
--- a/src/core/appdir_root_setup.cpp
+++ b/src/core/appdir_root_setup.cpp
@@ -188,6 +188,9 @@ namespace linuxdeploy {
                     << "set -e" << std::endl
                     << std::endl
                     << "this_dir=$(readlink -f $(dirname \"$0\"))" << std::endl
+                    << std::endl
+                    << "# set the location of the message catalog files" << std::endl
+                    << "export TEXTDOMAINDIR=\"$this_dir/usr/share/locale\"" << std::endl
                     << std::endl;
 
                 std::for_each(bf::directory_iterator(appRunHooksPath), bf::directory_iterator{}, [&oss](const bf::path& p) {


### PR DESCRIPTION
In order to allow internationalization with AppImage applications, we should set the `TEXTDOMAINDIR` environment variable.
This is mandatory to have `gettext` work properly (for more details, see https://www.gnu.org/software/bash/manual/html_node/Locale-Translation.html).