### PR TITLE
Add --exclude-library option.

### DIFF
--- a/include/linuxdeploy/core/appdir.h
+++ b/include/linuxdeploy/core/appdir.h
@@ -38,6 +38,9 @@ namespace linuxdeploy {
                     // shortcut for using a normal string instead of a path
                     explicit AppDir(const std::string& path);
 
+                    // Set additional shared library name patterns to be excluded from deployment.
+                    void setExcludeLibraryPatterns(const std::vector<std::string> &excludeLibraryPatterns);
+
                     // creates basic directory structure of an AppDir in "FHS" mode
                     bool createBasicStructure() const;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@ int main(int argc, char** argv) {
     args::ValueFlag<std::string> appDirPath(parser, "appdir", "Path to target AppDir", {"appdir"});
 
     args::ValueFlagList<std::string> sharedLibraryPaths(parser, "library", "Shared library to deploy", {'l', "library"});
+    args::ValueFlagList<std::string> excludeLibraryPatterns(parser, "pattern", "Shared library to exclude from deployment (glob pattern)", {"exclude-library"});
 
     args::ValueFlagList<std::string> executablePaths(parser, "executable", "Executable to deploy", {'e', "executable"});
 
@@ -110,6 +111,7 @@ int main(int argc, char** argv) {
     }
 
     appdir::AppDir appDir(appDirPath.Get());
+    appDir.setExcludeLibraryPatterns(excludeLibraryPatterns.Get());
 
     // allow disabling copyright files deployment via environment variable
     if (getenv("DISABLE_COPYRIGHT_FILES_DEPLOYMENT") != nullptr) {


### PR DESCRIPTION
Add `--exclude-library` path to allow excluding libraries in addition to the ones defined by the upstream `excludelist` file.

Closes #29.