### PR TITLE
Fixes #167 - Bump patchelf version to 0.14.5

### DIFF
--- a/ci/build-static-patchelf.sh
+++ b/ci/build-static-patchelf.sh
@@ -47,7 +47,7 @@ pushd "$BUILD_DIR"
 git clone https://github.com/NixOS/patchelf.git .
 
 # cannot use -b since it's not supported in really old versions of git
-git checkout 0.8
+git checkout 0.14.5
 
 # prepare configure script
 ./bootstrap.sh

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -46,9 +46,6 @@ cmake "$REPO_ROOT" -DSTATIC_BUILD=On -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_T
 
 make -j"$(nproc)"
 
-## Run Unit Tests
-ctest -V
-
 # build patchelf
 "$REPO_ROOT"/ci/build-static-patchelf.sh "$(readlink -f out/)"
 patchelf_path="$(readlink -f out/usr/bin/patchelf)"
@@ -57,8 +54,11 @@ patchelf_path="$(readlink -f out/usr/bin/patchelf)"
 "$REPO_ROOT"/ci/build-static-binutils.sh "$(readlink -f out/)"
 strip_path="$(readlink -f out/usr/bin/strip)"
 
-# use tools we just built for linuxdeploy run
+# use tools we just built for linuxdeploy test run
 export PATH="$(readlink -f out/usr/bin):$PATH"
+
+## Run Unit Tests
+ctest -V
 
 # args are used more than once
 LINUXDEPLOY_ARGS=("--appdir" "AppDir" "-e" "bin/linuxdeploy" "-i" "$REPO_ROOT/resources/linuxdeploy.png" "-d" "$REPO_ROOT/resources/linuxdeploy.desktop" "-e" "$patchelf_path" "-e" "$strip_path")


### PR DESCRIPTION
patchelf 0.8 is 9 years old; there have been a lot of bug fixes in the interim.

This has been submitted as a pull request so that I can get a CI build for testing purposes, because I can't find any documentation on the build process. The closest I've been able to get is to try and replicate the CI configuration locally, but I haven't had any success.