### PR TITLE
[debian] [copyright] Use canonical paths for dpkg-query

### DIFF
--- a/src/core/copyright/copyright_dpkgquery.cpp
+++ b/src/core/copyright/copyright_dpkgquery.cpp
@@ -10,7 +10,13 @@ namespace linuxdeploy {
             using namespace log;
 
             std::vector<fs::path> DpkgQueryCopyrightFilesManager::getCopyrightFilesForPath(const fs::path& path) {
-                subprocess::subprocess proc{{"dpkg-query", "-S", path.c_str()}};
+                const auto realpath = fs::canonical(path);
+
+                if (std::string(realpath) != std::string(path)) {
+                    ldLog() << LD_DEBUG << "Canonical path" << realpath << "not equivalent to" << path << std::endl;
+                }
+
+                subprocess::subprocess proc{{"dpkg-query", "-S", realpath.c_str()}};
 
                 auto result = proc.run();
 


### PR DESCRIPTION
This is guaranteed to always be better as the package containing a symlink is unlikely to be the actual owner of the package anyway.

A package will never contain only a symlink.