### PR TITLE
Fix warnings: -Wsubobject-linkage & -Wreturn-type

### DIFF
--- a/include/linuxdeploy/subprocess/pipe_reader.h
+++ b/include/linuxdeploy/subprocess/pipe_reader.h
@@ -20,6 +20,7 @@ public:
         SUCCESS = 0,
         TIMEOUT,
         END_OF_FILE,
+        RUNTIME_ERROR
     };
 
     /**

--- a/src/core/appdir.cpp
+++ b/src/core/appdir.cpp
@@ -32,7 +32,7 @@ using namespace cimg_library;
 
 namespace fs = std::filesystem;
 
-namespace {
+namespace private_items {
     // equivalent to 0644
     constexpr fs::perms DEFAULT_PERMS = fs::perms::owner_write | fs::perms::owner_read | fs::perms::group_read | fs::perms::others_read;
     // equivalent to 0755
@@ -97,6 +97,7 @@ namespace {
 namespace linuxdeploy {
     namespace core {
         namespace appdir {
+            using namespace private_items;
             class AppDir::PrivateData {
                 public:
                     fs::path appDirPath;

--- a/src/subprocess/pipe_reader.cpp
+++ b/src/subprocess/pipe_reader.cpp
@@ -56,4 +56,5 @@ pipe_reader::result pipe_reader::read(std::vector<std::string::value_type>& buff
             // this is a should-never-ever-happen case, a return value not handled by the lines above is actually not possible
             throw std::runtime_error{"unexpected return value from pollfd"};
     }
+    return result::RUNTIME_ERROR;
 }


### PR DESCRIPTION
Silences these two warnings:

* In file included from /home/fred/Workspace/linuxdeploy/src/appdir_test_main.cpp:10:
./linuxdeploy/src/core/appdir.cpp:100&zwnj;:27: warning: ‘linuxdeploy::core::appdir::AppDir::PrivateData’ has a field ‘linuxdeploy::core::appdir::AppDir::PrivateData::copyOperationsStorage’ whose type uses the anonymous namespace [**-Wsubobject-linkage**]
* In member function ‘pipe_reader::result pipe_reader::read(std::vector<char>&, std::chrono::milliseconds)’: 
./linuxdeploy/src/subprocess/pipe_reader.cpp:59:1: warning: control reaches end of non-void function [**-Wreturn-type**]