### PR TITLE
Fix rpath for libraries in subfolders of usr/lib and for executables in usr/lib/libexec

### DIFF
--- a/src/core/appdir.cpp
+++ b/src/core/appdir.cpp
@@ -807,13 +807,30 @@ namespace linuxdeploy {
                     executables.push_back(file);
                 }
 
+                for (const auto& file : listFilesInDirectory(path() / "usr/lib/libexec", true)) {
+                    // make sure it's an ELF file
+                    try {
+                        elf_file::ElfFile elfFile(file);
+                    } catch (const elf_file::ElfFileParseError&) {
+                        // FIXME: remove this workaround once the MIME check below works as intended
+                        continue;
+                    }
+
+                    executables.push_back(file);
+                }
+
                 return executables;
             }
 
             std::vector<fs::path> AppDir::listSharedLibraries() const {
+                const auto libexecPath = (path() / "usr/lib/libexec/").string();
                 std::vector<fs::path> sharedLibraries;
 
                 for (const auto& file : listFilesInDirectory(path() / "usr" / "lib", true)) {
+                    // skip executables in libexec
+                    if (util::stringStartsWith(file.string(), libexecPath))
+                        continue;
+
                     // exclude debug symbols
                     if (d->isInDebugSymbolsLocation(file))
                         continue;
@@ -840,7 +857,12 @@ namespace linuxdeploy {
                     if (!d->deployElfDependencies(executable))
                         return false;
 
-                    std::string rpath = "$ORIGIN/../" + PrivateData::getLibraryDirName(executable);
+                    // set rpath correctly
+                    const auto rpathDestination = path() / "usr" / PrivateData::getLibraryDirName(executable);
+                    ldLog() << LD_DEBUG << "rpath destination:" << rpathDestination << std::endl;
+
+                    const auto rpath = PrivateData::calculateRelativeRPath(executable.parent_path(), rpathDestination, false);
+                    ldLog() << LD_DEBUG << "Calculated rpath:" << rpath << std::endl;
 
                     d->setElfRPathOperations[executable] = rpath;
                 }

--- a/src/core/appdir.cpp
+++ b/src/core/appdir.cpp
@@ -385,13 +385,13 @@ namespace linuxdeploy {
                         return stripPath;
                     }
 
-                    static std::string calculateRelativeRPath(const fs::path& originDir, const fs::path& dependencyLibrariesDir) {
+                    static std::string calculateRelativeRPath(const fs::path& originDir, const fs::path& dependencyLibrariesDir, bool appendOrigin = true) {
                         auto relPath = fs::relative(fs::absolute(dependencyLibrariesDir), fs::absolute(originDir));
                         if (relPath.empty() || relPath == ".") {
                             return "$ORIGIN";
                         } else {
-                            auto rpath = "$ORIGIN/" + relPath.string() + ":$ORIGIN";
-                            return rpath;
+                            auto rpath = "$ORIGIN/" + relPath.string();
+                            return appendOrigin ? rpath + ":$ORIGIN" : rpath;
                         }
                     }
 

--- a/src/core/appdir.cpp
+++ b/src/core/appdir.cpp
@@ -387,8 +387,12 @@ namespace linuxdeploy {
 
                     static std::string calculateRelativeRPath(const fs::path& originDir, const fs::path& dependencyLibrariesDir) {
                         auto relPath = fs::relative(fs::absolute(dependencyLibrariesDir), fs::absolute(originDir));
-                        std::string rpath = "$ORIGIN/" + relPath.string() + ":$ORIGIN";
-                        return rpath;
+                        if (relPath.empty() || relPath == ".") {
+                            return "$ORIGIN";
+                        } else {
+                            auto rpath = "$ORIGIN/" + relPath.string() + ":$ORIGIN";
+                            return rpath;
+                        }
                     }
 
                     bool deployLibrary(const fs::path& path, bool forceDeploy = false, bool deployDependencies = true, const fs::path& destination = fs::path()) {

--- a/src/plugin/plugin_process_handler.cpp
+++ b/src/plugin/plugin_process_handler.cpp
@@ -3,6 +3,7 @@
 #include <thread>
 #include <tuple>
 #include <utility>
+#include <array>
 
 // local headers
 #include <linuxdeploy/plugin/plugin_process_handler.h>

--- a/src/subprocess/subprocess.cpp
+++ b/src/subprocess/subprocess.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <unistd.h>
 #include <thread>
+#include <array>
 
 // local headers
 #include "linuxdeploy/subprocess/subprocess.h"


### PR DESCRIPTION
This is an attempt to make the rpaths of ELF files in subfolders of usr/lib more correct (if I understand rpath correctly).