### PR TITLE
Checking if a path is a directory is broken

### DIFF
--- a/src/core/appdir.cpp
+++ b/src/core/appdir.cpp
@@ -158,7 +158,7 @@ namespace linuxdeploy {
                                 return false;
                             }
 
-                            if (*(to.string().end() - 1) == '/' || fs::is_directory(to))
+                            if (to.string().back() == '/' || fs::is_directory(to))
                                 to /= from.filename();
 
                             if (!overwrite && fs::exists(to)) {


### PR DESCRIPTION
Checking if a path is a directory, by checking if there is a slash at the end of the path, was inconsistent and broken in one case. All string checks of paths being a directory are now the same.

This is the resolution for issue #244 

Closes #244.