### PR TITLE
List shared libraries in lib32 and lib64

### DIFF
--- a/src/core/appdir.cpp
+++ b/src/core/appdir.cpp
@@ -807,22 +807,25 @@ namespace linuxdeploy {
             }
 
             std::vector<fs::path> AppDir::listSharedLibraries() const {
+                static const std::vector<std::string> libDirectories = {"lib", "lib32", "lib64"};
                 std::vector<fs::path> sharedLibraries;
 
-                for (const auto& file : listFilesInDirectory(path() / "usr" / "lib", true)) {
-                    // exclude debug symbols
-                    if (d->isInDebugSymbolsLocation(file))
-                        continue;
+                for (const std::string &libDirectory : libDirectories) {
+                    for (const auto& file : listFilesInDirectory(path() / "usr" / libDirectory, true)) {
+                        // exclude debug symbols
+                        if (d->isInDebugSymbolsLocation(file))
+                            continue;
 
-                    // make sure it's an ELF file
-                    try {
-                        elf_file::ElfFile elfFile(file);
-                    } catch (const elf_file::ElfFileParseError&) {
-                        // FIXME: remove this workaround once the MIME check below works as intended
-                        continue;
+                        // make sure it's an ELF file
+                        try {
+                            elf_file::ElfFile elfFile(file);
+                        } catch (const elf_file::ElfFileParseError&) {
+                            // FIXME: remove this workaround once the MIME check below works as intended
+                            continue;
+                        }
+
+                        sharedLibraries.push_back(file);
                     }
-
-                    sharedLibraries.push_back(file);
                 }
 
                 return sharedLibraries;


### PR DESCRIPTION
I get this error when I create an armhf AppImage for my Qt-based application:
```
...
Setting rpath in ELF file AppDir/usr/lib32/libicuuc.so.66 to $ORIGIN 
Setting rpath in ELF file AppDir/usr/lib32/liblz4.so.1 to $ORIGIN 
Setting rpath in ELF file AppDir/usr/lib32/liblzma.so.5 to $ORIGIN 
Setting rpath in ELF file AppDir/usr/lib32/libpcre.so.3 to $ORIGIN 
Setting rpath in ELF file AppDir/usr/lib32/libpcre2-16.so.0 to $ORIGIN 
Setting rpath in ELF file AppDir/usr/lib32/libpng16.so.16 to $ORIGIN 
Setting rpath in ELF file AppDir/usr/lib32/libsystemd.so.0 to $ORIGIN 
Setting rpath in ELF file AppDir/usr/lib32/libxkbcommon.so.0 to $ORIGIN 

-- Running input plugin: qt -- 
[qt/stdout] Using qmake: /home/runner/work/Open-Typer/Open-Typer/qt-cross/bin/qmake 
[qt/stderr] linuxdeploy-plugin-qt version 1-alpha (git commit ID 9a388d3), GitHub actions build 1098 built on 2023-07-08 14:57:12 UTC
[qt/stdout] 
[qt/stdout] Using Qt version:  6.5.1  ( 6 ) 
[qt/stdout] 
[qt/stdout] Found Qt modules:  
[qt/stdout] Extra Qt modules: 
[qt/stdout] ERROR: Could not find Qt modules to deploy
ERROR: Failed to run plugin: qt (exit code: 1)
```

As you can see, linuxdeploy deploys the libraries to `{AppDir}/usr/lib32` instead of `lib`

The problem is that linuxdeploy-plugin-qt uses the AppDir::listSharedLibraries() method which looks for libraries in `{AppDir}/usr/lib` only. Making it look for libraries in `lib32` resolves this issue. I've also added the `lib64` directory just in case it's used for some architecture.

I'm not sure whether this is a good fix, but it works for my app.