### PR TITLE
ci: Updated the 'checkout' and 'download-artifact' actions to version 3.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       USE_STATIC_RUNTIME: ${{ matrix.USE_STATIC_RUNTIME }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Inspect directory after downloading artifacts
         run: ls -alFR
       - name: Create release and upload artifacts


### PR DESCRIPTION
The version 2 of these actions is deprecated due to their use of Node.js 12 that is also deprecated.