### PR TITLE
Fix compilation errors due to missing <array> includes.

### DIFF
--- a/src/plugin/plugin_process_handler.cpp
+++ b/src/plugin/plugin_process_handler.cpp
@@ -1,4 +1,5 @@
 // system headers
+#include <array>
 #include <filesystem>
 #include <thread>
 #include <tuple>

--- a/src/subprocess/subprocess.cpp
+++ b/src/subprocess/subprocess.cpp
@@ -1,5 +1,6 @@
 // system headers
 #include <algorithm>
+#include <array>
 #include <iostream>
 #include <memory>
 #include <stdexcept>


### PR DESCRIPTION
These two files create buffers using `std::array`, but the compiler doesn't know about the type, leading to compilation failures.