### PR TITLE
Pass exclude-libraries as env var to linuxdeploy plugins

### DIFF
--- a/include/linuxdeploy/util/misc.h
+++ b/include/linuxdeploy/util/misc.h
@@ -135,7 +135,33 @@ namespace linuxdeploy {
                 }
 
                 return {};
-            };
+            }
+
+            // sets value variable with value from envVar if exists
+            static bool charFromEnv(const char *envVar, char &value) {
+                const auto ret = getenv(envVar);
+                if (ret && strlen(ret) == 1) {
+                    value = ret[0];
+                    return true;
+                }
+                return false;
+            }
+
+            // sets strings vector with strings from envVar if exists
+            static bool stringVectorFromEnv(const char *envVar, char delimiter, std::vector<std::string> &strings) {
+                const auto ret = getenv(envVar);
+                if (ret) {
+                    strings = split(ret, delimiter);
+                    return true;
+                }
+                return false;
+            }
+
+            // set envVar with value from strings
+            static bool stringVectorToEnv(const char *envVar, char delimiter, const std::vector<std::string> &strings) {
+                const auto ret = join(strings, std::string{delimiter});
+                return setenv(envVar, ret.c_str(), 1) == 0;
+            }
         }
     }
 }

--- a/src/core/appdir.cpp
+++ b/src/core/appdir.cpp
@@ -119,13 +119,18 @@ namespace linuxdeploy {
                     // platform dependent implementation of copyright files deployment
                     std::shared_ptr<copyright::ICopyrightFilesManager> copyrightFilesManager;
 
+                    // Enviroment variable delimiter
+                    char envDelimiter = ';';
+
                     // decides whether copyright files deployment is performed
                     bool disableCopyrightFilesDeployment = false;
 
                 public:
                 PrivateData() : copyOperationsStorage(), stripOperations(), setElfRPathOperations(), visitedFiles(), appDirPath(), excludeLibraryPatterns() {
                         copyrightFilesManager = copyright::ICopyrightFilesManager::getInstance();
-                    };
+                        util::misc::charFromEnv("LINUXDEPLOY_DELIMITER", envDelimiter);
+                        util::misc::stringVectorFromEnv("LINUXDEPLOY_EXCLUDED_LIBRARIES", envDelimiter, excludeLibraryPatterns);
+                    }
 
                 public:
                     // calculate library directory name for given ELF file, taking system architecture into account
@@ -656,6 +661,7 @@ namespace linuxdeploy {
             AppDir::AppDir(const std::string& path) : AppDir(fs::path(path)) {}
 
             void AppDir::setExcludeLibraryPatterns(const std::vector<std::string> &excludeLibraryPatterns) {
+                util::misc::stringVectorToEnv("LINUXDEPLOY_EXCLUDED_LIBRARIES", d->envDelimiter, excludeLibraryPatterns);
                 d->excludeLibraryPatterns = excludeLibraryPatterns;
             }
 


### PR DESCRIPTION
Excluding libraries doesn't properly work as of now because plugins are not notified of such exclusions, by passing the env var and automatically reading it plugins just need to be recompiled.

This fixes https://github.com/linuxdeploy/linuxdeploy-plugin-qt/issues/153