### PR TITLE
Add automatic excludelist updating at runtime

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,6 +111,13 @@ int main(int argc, char** argv) {
     appdir::AppDir appDir(appDirPath.Get());
     appDir.setExcludeLibraryPatterns(excludeLibraryPatterns.Get());
 
+    // update excludelist
+    ldLog() << std::endl << "-- Updating excludelist --" << std::endl;
+    if (!appDir.updateExcludelist()) {
+    	ldLog() << LD_WARNING << "Failed to update excludelist, using packaged copy" << std::endl;
+    	ldLog() << LD_WARNING << "Please run linuxdeploy with internet access or update it" << std::endl;
+    }
+
     // allow disabling copyright files deployment via environment variable
     if (getenv("DISABLE_COPYRIGHT_FILES_DEPLOYMENT") != nullptr) {
         ldLog() << std::endl << LD_WARNING << "Copyright files deployment disabled" << std::endl;


### PR DESCRIPTION
This pull request adds an automatic excludelist updating mechanism at runtime.

With this pull request, each time the `linuxdeploy` command is invoked, it will try to download the current version of the excludelist, parse it and save it as a vector. If any of these steps fail, a warning is emitted.
For each library that should be tested against the excludelist, the newly downloaded excludelist will be used if it has been saved correctly, and the pre-packaged excludelist otherwise.

This feature is added because of the reasons stated in #286: Currently, it requires a new `linuxdeploy` version to be shipped and downloaded / used by everyone in order for excludelist changes to take effect. This also means that updates have to "trickle down" (e.g. when someone uses a framework like `tauri` that itself uses `linuxdeploy`) and it creates a single point of failure (a possible missing new `linuxdeploy` version).

This fixes #286.