### PR TITLE
Add CLI option to deploy an appstream file

### DIFF
--- a/src/core/appdir.cpp
+++ b/src/core/appdir.cpp
@@ -636,6 +636,22 @@ namespace linuxdeploy {
                         return true;
                     }
 
+                    // TODO: Reduce duplicated code between deploy methods
+
+                    bool deployAppstreamFile(const fs::path& path) {
+                    	if (hasBeenVisitedAlready(path)) {
+                        	ldLog() << LD_DEBUG << "File has been visited already:" << desktopFile.path() << std::endl;
+                            return true;
+                        }
+
+                        ldLog() << "Deploying appstream file" << path << std::endl;
+
+                        auto filename = path.filename().string();
+                        deployFile(path, appDirPath / "usr/share/metainfo" / filename, DEFAULT_PERMS);
+
+                        return true;
+                    }
+
                     static bool isInDebugSymbolsLocation(const fs::path& path) {
                         // TODO: check if there's more potential locations for debug symbol files
                         for (const std::string& dbgSymbolsPrefix : {".debug/"}) {
@@ -714,6 +730,10 @@ namespace linuxdeploy {
 
             bool AppDir::deployIcon(const fs::path& path, const std::string& targetFilename) {
                 return d->deployIcon(path, targetFilename);
+            }
+
+            bool AppDir::deployAppstreamFile(const fs::path& path) {
+            	return d->deployAppstreamFile(path);
             }
 
             bool AppDir::executeDeferredOperations() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char** argv) {
     args::Flag showVersion(parser, "", "Print version and exit", {'V', "version"});
     args::ValueFlag<int> verbosity(parser, "verbosity", "Verbosity of log output (0 = debug, 1 = info (default), 2 = warning, 3 = error)", {'v', "verbosity"});
 
-    args::ValueFlag<std::string> appDirPath(parser, "appdir", "Path to target AppDir", {"appdir"});
+    args::ValueFlag<std::string> appDirPath(parser, "appdir", "Path to target AppDir", {'a', "appdir"});
 
     args::ValueFlagList<std::string> sharedLibraryPaths(parser, "library", "Shared library to deploy", {'l', "library"});
     args::ValueFlagList<std::string> excludeLibraryPatterns(parser, "pattern", "Shared library to exclude from deployment (glob pattern)", {"exclude-library"});
@@ -42,6 +42,8 @@ int main(int argc, char** argv) {
 
     args::ValueFlagList<std::string> iconPaths(parser, "icon file", "Icon to deploy", {'i', "icon-file"});
     args::ValueFlag<std::string> iconTargetFilename(parser, "filename", "Filename all icons passed via -i should be renamed to", {"icon-filename"});
+
+    args::ValueFlag<std::string> appstreamPath(parser, "appstream file", "Appstream file to deploy", {"appstream-file"});
 
     args::ValueFlag<std::string> customAppRunPath(parser, "AppRun path", "Path to custom AppRun script (linuxdeploy will not create a symlink but copy this file instead)", {"custom-apprun"});
 
@@ -273,6 +275,20 @@ int main(int argc, char** argv) {
                 ldLog() << LD_ERROR << "Failed to deploy desktop file: " << desktopFilePath << std::endl;
                 return 1;
             }
+        }
+    }
+
+    // deploy appstream file to usr/share/metainfo
+    if (appstreamPath) {
+    	appstreamPath = appstreamPath.Get();
+    	if (!fs::exists(appstreamPath)) {
+            ldLog() << LD_ERROR << "No such file or directory: " << appstreamPath << std::endl;
+            return 1;
+        }
+
+    	if (!appDir.deployAppstreamFile(appstreamPath)) {
+            ldLog() << LD_ERROR << "Failed to deploy appstream file: " << appstreamPath << std::endl;
+            return 1;
         }
     }
 


### PR DESCRIPTION
This pull request adds a CLI flag to deploy an appstream file. When used, the appstream file under the given path will be copied into usr/share/metainfo. This way, users won't have to create an AppDir and manually add the file to the correct location in order for the AppImage to contain one.
It also adds the `-a` shortcut to the AppDir flag.