### PR TITLE
Add usr/share/pixmaps to the basic structure

### DIFF
--- a/src/core/appdir.cpp
+++ b/src/core/appdir.cpp
@@ -665,6 +665,7 @@ namespace linuxdeploy {
                     "usr/lib/",
                     "usr/share/applications/",
                     "usr/share/icons/hicolor/",
+                    "usr/share/pixmaps/",
                 };
 
                 for (const std::string& resolution : {"16x16", "32x32", "64x64", "128x128", "256x256", "scalable"}) {

--- a/tests/core/test_appdir.cpp
+++ b/tests/core/test_appdir.cpp
@@ -77,6 +77,7 @@ namespace AppDirTest {
             "usr/share/icons/hicolor/64x64",
             "usr/share/icons/hicolor/64x64/apps",
             "usr/share/applications",
+            "usr/share/pixmaps",
             "usr/lib",
         };
 


### PR DESCRIPTION
This folder is required by the deployment step and will cause an error if it's not there.

Add it along with the icons folders in `createBasicStructure`
