### PR TITLE
--deploy-deps-only: Improve wording

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv) {
 
     args::ValueFlagList<std::string> executablePaths(parser, "executable", "Executable to deploy", {'e', "executable"});
 
-    args::ValueFlagList<std::string> deployDepsOnlyPaths(parser, "path", "Path to ELF file or directory containing such files (libraries or executables) in the AppDir whose dependencies shall be deployed by linuxdeploy without copying them into the AppDir", {"deploy-deps-only"});
+    args::ValueFlagList<std::string> deployDepsOnlyPaths(parser, "path", "Path to ELF file or directory containing such files (libraries or executables) already present in the AppDir whose dependencies shall be deployed by linuxdeploy without copying them again into the AppDir.  rpath for these libraries or executables will be updated accordingly.", {"deploy-deps-only"});
 
     args::ValueFlagList<std::string> desktopFilePaths(parser, "desktop file", "Desktop file to deploy", {'d', "desktop-file"});
     args::Flag createDesktopFile(parser, "", "Create basic desktop file that is good enough for some tests", {"create-desktop-file"});


### PR DESCRIPTION
Improve clarity, remove ambiguity about flag.
Related
* #305

---

Quoting history of this, from #305:

@tresf wrote:
> Previously, I used `-executable` flag. Starting with `linuxdepoy`, I've tried both the `--executable` and the `--library` flags but I'm struggling to keep the expected layout.

@TheAssassin wrote:
> [You should] `make install` the install tree to the `AppDir`, then use `linuxdeploy` with `--deploy-deps-only` to deploy the dependencies of the files in the subdirectories to `usr/lib` (while also setting their `rpath` accordingly, but **without deploying the libraries themselves again** into `usr/lib`). `-l` is meant for the manual packaging mode (e.g., when **not** using `make install` at all).
> [...]
> For libraries in directories passed to `--deploy-deps-only`, `linuxdeploy` sets the correct `rpath` and deploys their dependencies into `usr/lib`.

@tresf wrote:
>  Great this will fix the problem outright. Will [test and confirm]

@TheAssassin wrote:
> I think the flag's help text explains this already: it is used on files already inside the AppDir.

@tresf wrote:
> I agree in hindsight, but at first read, it was not obvious... [...]

@TheAssassin wrote:
> Thanks for the improved wording. Could you send a PR, please?